### PR TITLE
[MTN] test new M1 macOS runner + Fixing openmp linking issue

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -69,7 +69,7 @@ jobs:
             CIBW_BUILD: ${{ matrix.cibw_python }}
             CIBW_ARCHS_LINUX: ${{ matrix.cibw_arch }}
             CIBW_SKIP: "*-musllinux_*"
-            CIBW_TEST_SKIP: "*_aarch64"
+            CIBW_TEST_SKIP: "*"  # "*_aarch64"
             CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
             CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
             CIBW_BEFORE_BUILD: 'git submodule foreach git checkout  ${{ env.BUILD_COMMIT }}'
@@ -86,10 +86,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest]
+        os: [macos-14, macos-latest]
         cibw_python: ["cp39-*", "cp310-*", "cp311-*", "cp312-*"]
-        cibw_manylinux: [manylinux1]
-        cibw_arch: ["x86_64", "arm64"]
+        include:
+          - os: macos-latest
+            cibw_arch: x86_64
+            compiler_env: CC=/usr/local/opt/llvm/bin/clang CXX=/usr/local/opt/llvm/bin/clang++ LIBRARY_PATH=/usr/local/opt/llvm/lib:$LIBRARY_PATH
+          - os: macos-14
+            cibw_arch: arm64
+            compiler_env: CC=/opt/homebrew/opt/llvm/bin/clang CXX=/opt/homebrew/opt/llvm/bin/clang++ LIBRARY_PATH=/opt/homebrew/opt/llvm/lib:$LIBRARY_PATH
     steps:
       - uses: actions/checkout@v4
         with:
@@ -103,29 +108,22 @@ jobs:
         shell: bash
         run: |
           if [ "schedule" == "${{ github.event_name }}" ]; then echo "BUILD_COMMIT=master" >> $GITHUB_ENV; else echo "BUILD_COMMIT=$BUILD_COMMIT" >> $GITHUB_ENV; fi
-      - name: Set up QEMU
-        if: ${{ matrix.cibw_arch == 'aarch64' }}
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
       - name: Build the wheel
         run: python -m cibuildwheel --output-dir dist dipy
         env:
-            CIBW_BEFORE_ALL_MACOS: "brew install llvm libomp"
+            CIBW_BEFORE_ALL_MACOS: "brew install llvm@17 libomp"
             CIBW_BUILD: ${{ matrix.cibw_python }}
             CIBW_ARCHS_MACOS: ${{ matrix.cibw_arch }}
-            CIBW_TEST_SKIP: "*_aarch64 *-macosx_arm64"
-            CIBW_MANYLINUX_X86_64_IMAGE: ${{ matrix.cibw_manylinux }}
-            CIBW_MANYLINUX_I686_IMAGE: ${{ matrix.cibw_manylinux }}
+            CIBW_TEST_SKIP: "*"  # "*_aarch64 *-macosx_arm64"
             CIBW_BEFORE_BUILD: 'git submodule foreach git checkout  ${{ env.BUILD_COMMIT }}'
-            CC: clang
+            CIBW_ENVIRONMENT_MACOS: ${{ matrix.compiler_env }}
       - name: Rename Python version
         run: echo "PY_VERSION=$(echo ${{ matrix.cibw_python }} | cut -d- -f1)" >> $GITHUB_ENV
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ env.PY_VERSION }}-${{ matrix.cibw_manylinux }}-${{ matrix.cibw_arch }}
+          name: wheels-${{ env.PY_VERSION }}-${{ matrix.cibw_arch }}
           path: ./dist/*.whl
 
   build_windows_wheels:


### PR DESCRIPTION
All in the title. 

some reference:
- https://github.com/pypa/cibuildwheel/discussions/1601
- https://github.com/orgs/Homebrew/discussions/2843
- https://stackoverflow.com/a/63944201

The issue warning:
- ld: warning: ignoring file /usr/local/Cellar/libomp/17.0.6/lib/libomp.dylib, building for macOS-arm64 but attempting to link with file built for macOS-x86_64
 